### PR TITLE
Shortened description text to the one used on Google Fonts

### DIFF
--- a/DESCRIPTION.en_us.html
+++ b/DESCRIPTION.en_us.html
@@ -1,17 +1,13 @@
 <p>
-    Ysabeau combines the familiar timeless letterforms of the Garamond legacy with the unencumbered crispness of a clean low-contrast sans serif. Unlike other humanist sans, Ysabeau retains the confident wide stride and unapologetic extenders of the world's favorite book face for unmitigated reading comfort. Try it on your e-reader and never look back! Pair it with <i>EB Garamond</i> or <i>Cormorant</i> for a perfect match, or blow it up to page-filling sizes and revel in its elegance.
+    Ysabeau combines the familiar timeless letterforms of the Garamond legacy with the unencumbered crispness of a clean
+    low-contrast sans serif. Unlike other humanist sans, Ysabeau retains the confident wide stride and unapologetic
+    extenders of the world's favorite book face for unmitigated reading comfort. Try it on your e-reader and never look
+    back! Pair it with <i>EB Garamond</i> or <i>Cormorant</i> for a perfect match, or blow it up to page-filling sizes
+    and revel in its elegance.
 </p>
 <p>
-    Ysabeau offers extensive Latin, Greek and Cyrillic coverage with small caps, contextual and stylistic alternates, and classic Garamond-style ligatures. If you don't like ligatures, just disable them and let the contextual alternates take care of collisions instead! 
+    Ysabeau offers extensive Latin, Greek and Cyrillic.
 </p>
 <p>
-	The spin-off fonts Ysabeau Office, Ysabeau Infant, and Ysabeau SC offer selected sets of OpenType variants promoted to default for ease of use:
-</p>
-<ul>
-  <li><i>Ysabeau Office</i> is an exercise in restraint. It suppresses the flamboyant long «Q» alternates, turns the slanted hyphen horizontal, and replaces the old-style figures with tabular lining figures.</li>
-  <li><i>Ysabeau Infant</i> features single-storey designs for «a» and «g», a script-style «y», a tailed «l», Bulgarian Cyrillic forms, and proportional lining figures.</li>
-  <li><i>Ysabeau SC</i> replaces the lowercase with small caps.</li>
-</ul> 
-<p>
-    To contribute, please see <a href="https://github.com/CatharsisFonts/Ysabeau">github.com/CatharsisFonts/Ysabeau</a>.
+    To contribute, see <a href="http://github.com/CatharsisFonts/Ysabeau">github.com/CatharsisFonts/Ysabeau</a>.
 </p>


### PR DESCRIPTION
Sorry for the annoying frequent updates. Your repository contained an older description file that was much longer and had already been shortened. This now reflects what we originally wanted to see published on Google Fonts.